### PR TITLE
Add environment variable to pre-commit action to skip commits to branch

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -24,6 +24,8 @@ jobs:
         uses: ./.github/actions/setup_dev_environment
       - name: Pre-commit Linting
         uses: ./.github/actions/pre-commit
+        env:
+          SKIP: no-commit-to-branch
       - name: Run Unit Tests
         run: |
           invoke tests.all


### PR DESCRIPTION
Fixes failing pre-commit when run from the build_push action on main