### PR TITLE
IDEA Release 25.06.2 - bugfix patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This maintenance release addresses critical stability and compatibility issues i
 
 * **TailFile API Optimization**: Refactored to reduce memory consumption and prevent OOM crashes in cluster-manager supervisord process
 * **Windows Server 2025 GPU Support**: Fixed NVIDIA GPU compatibility by using Windows Server 2022 drivers (Windows Server 2025 drivers not yet available from AWS)
+* **YAML Config Generation**: Fixed YAML Formatting issue preventing `upgrade-cluster` from running successfully
 
 ## [25.06.1] - 2025-06-10
 

--- a/source/idea/idea-administrator/resources/config/templates/shared-storage/_templates/efs.yml
+++ b/source/idea/idea-administrator/resources/config/templates/shared-storage/_templates/efs.yml
@@ -1,8 +1,8 @@
 efs:
-  {% if kwargs.use_existing_fs %}
+{% if kwargs.use_existing_fs %}
   use_existing_fs: true
   file_system_id: "{{ kwargs.file_system_id }}" # if an existing file system id is provided, provisioning of EFS will be skipped and above parameters will be applied as is. existing file system is supported only when using existing vpc.
-  {% else %}
+{% else %}
   kms_key_id: {{ kwargs.kms_key_id or '~' }} # Specify your own CMK to encrypt EFS file system. If set to ~ encryption will be managed by the default AWS key
   throughput_mode: "bursting" # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html#cfn-efs-filesystem-throughputmode
   performance_mode: "generalPurpose" # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html#cfn-efs-filesystem-performancemode
@@ -10,4 +10,4 @@ efs:
   removal_policy: "DESTROY" # RETAIN will preserve the EFS even if you delete the stack.
   cloudwatch_monitoring: {{ ( kwargs.efs.cloudwatch_monitoring or False ) | lower }}
   transition_to_ia: {{ kwargs.efs.transition_to_ia or '~' }}
-  {% endif %}
+{% endif %}

--- a/source/idea/idea-administrator/resources/config/templates/shared-storage/settings.yml
+++ b/source/idea/idea-administrator/resources/config/templates/shared-storage/settings.yml
@@ -4,9 +4,9 @@
 
 {% macro storage_provider_config(provider, kwargs) %}
 {% if provider == 'efs' %}
-  {% include 'shared-storage/_templates/efs.yml' %}
+{% include 'shared-storage/_templates/efs.yml' %}
 {% elif provider == 'fsx_lustre' %}
-  {% include 'shared-storage/_templates/fsx_lustre.yml' %}
+{% include 'shared-storage/_templates/fsx_lustre.yml' %}
 {% endif %}
 {% endmacro %}
 
@@ -22,7 +22,7 @@ apps:
   #mount_options: "efs _netdev,noresvport,tls,iam 0 0"
   scope:
     - cluster
-  {{ storage_provider_config(provider=storage_apps_provider, kwargs={
+{{ storage_provider_config(provider=storage_apps_provider, kwargs={
       'use_existing_fs': use_existing_apps_fs,
       'file_system_id': existing_apps_fs_id,
       'kms_key_id': kms_key_id,
@@ -46,7 +46,7 @@ data:
   #mount_options: "efs _netdev,noresvport,tls,iam 0 0"
   scope:
     - cluster
-  {{ storage_provider_config(provider=storage_data_provider, kwargs={
+{{ storage_provider_config(provider=storage_data_provider, kwargs={
       'use_existing_fs': use_existing_data_fs,
       'file_system_id': existing_data_fs_id,
       'kms_key_id': kms_key_id,


### PR DESCRIPTION
### **🔧 Critical Hotfixes**

This maintenance release addresses critical stability and compatibility issues in the Virtual Desktop Controller (VDC) and Cluster Manager components.

**Upgrade Instructions:**
* From `25.05.1`: Update only `vdc` and `cluster-manager` (non-service impacting)
```bash
./idea-admin.sh upgrade-cluster cluster-manager vdc --aws-region $IDEA_AWS_REGION --cluster-name $IDEA_CLUSTER_NAME
```
* From other versions: Run full `upgrade-cluster` ([documentation](https://docs.idea-hpc.com/first-time-users/cluster-operations/update-idea-cluster/upgrade-cluster))

### **🔄 Updates**
* Software Stack and Base AMIs updated
* Fixed changelog link typos

### **🐛 Bug Fixes**

* **TailFile API Optimization**: Refactored to reduce memory consumption and prevent OOM crashes in cluster-manager supervisord process
* **Windows Server 2025 GPU Support**: Fixed NVIDIA GPU compatibility by using Windows Server 2022 drivers (Windows Server 2025 drivers not yet available from AWS)
* **YAML Config Generation**: Fixed YAML Formatting issue preventing `upgrade-cluster` from running successfully
