### PR TITLE
IDEA 25.06.2 Scheduler Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This maintenance release addresses critical stability and compatibility issues i
 * **TailFile API Optimization**: Refactored to reduce memory consumption and prevent OOM crashes in cluster-manager supervisord process
 * **Windows Server 2025 GPU Support**: Fixed NVIDIA GPU compatibility by using Windows Server 2022 drivers (Windows Server 2025 drivers not yet available from AWS)
 * **YAML Config Generation**: Fixed YAML Formatting issue preventing `upgrade-cluster` from running successfully
+* **Scheduler Default Queues**: Fixed placement group default settings for queues that prevented new scheduler deployments
 
 ## [25.06.1] - 2025-06-10
 

--- a/source/idea/idea-scheduler/src/ideascheduler/app/scheduler_default_settings.py
+++ b/source/idea/idea-scheduler/src/ideascheduler/app/scheduler_default_settings.py
@@ -114,7 +114,7 @@ class SchedulerDefaultSettings:
                         instance_types=['t3.large', 't3.xlarge', 't3.2xlarge'],
                         base_os=compute_node_os,
                         instance_ami=compute_node_ami,
-                        enable_placement_group=True,
+                        enable_placement_group=False,
                     ),
                     projects=[Project(project_id=project.project_id)],
                 )
@@ -142,7 +142,7 @@ class SchedulerDefaultSettings:
                         instance_types=['t3.micro'],
                         base_os=compute_node_os,
                         instance_ami=compute_node_ami,
-                        enable_placement_group=True,
+                        enable_placement_group=False,
                     ),
                     projects=[Project(project_id=project.project_id)],
                 )


### PR DESCRIPTION
### **🔧 Critical Hotfixes**

This maintenance release addresses critical stability and compatibility issues in the Virtual Desktop Controller (VDC) and Cluster Manager components.

**Upgrade Instructions:**
* From `25.05.1`: Update only `vdc` and `cluster-manager` (non-service impacting)
```bash
./idea-admin.sh upgrade-cluster cluster-manager vdc --aws-region $IDEA_AWS_REGION --cluster-name $IDEA_CLUSTER_NAME
```
* From other versions: Run full `upgrade-cluster` ([documentation](https://docs.idea-hpc.com/first-time-users/cluster-operations/update-idea-cluster/upgrade-cluster))

### **🔄 Updates**
* Software Stack and Base AMIs updated
* Fixed changelog link typos

### **🐛 Bug Fixes**

* **TailFile API Optimization**: Refactored to reduce memory consumption and prevent OOM crashes in cluster-manager supervisord process
* **Windows Server 2025 GPU Support**: Fixed NVIDIA GPU compatibility by using Windows Server 2022 drivers (Windows Server 2025 drivers not yet available from AWS)
* **YAML Config Generation**: Fixed YAML Formatting issue preventing `upgrade-cluster` from running successfully
* **Scheduler Default Queues**: Fixed placement group default settings for queues that prevented new scheduler deployments
