### PR TITLE
Update GitHub Actions to use 'ubuntu-large'

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-large

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -14,7 +14,7 @@ on:
         type: string
 jobs:
   build_push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-large
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/lint_build.yaml
+++ b/.github/workflows/lint_build.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   lint_and_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-large
     steps:
       - uses: actions/checkout@v4
       - name: Pre-commit Linting

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-large
     steps:
       - uses: actions/checkout@v4
       - name: Setup Development Environment


### PR DESCRIPTION
Build runs taking quite long. Update runners to github hosted large runners
