### PR TITLE
ci: skip the branch protection hook when pre-commit runs in CI

### DIFF
--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -32,3 +32,6 @@ runs:
         key: pre-commit-3|${{ env.PYTHON_PATH }}|${{ runner.arch }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
       shell: bash
+      env:
+        # the hook guards local commits on protected branches; a workflow running on main is not one
+        SKIP: no-commit-to-branch


### PR DESCRIPTION
The no-commit-to-branch hook exists to stop local commits on main. The Build Tests workflow runs pre-commit on main after a merge, where the hook fails by design and marks the run red although nothing is wrong. Skip it for the CI run only.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
